### PR TITLE
updated plugin to use makeprg='cmake --build' 

### DIFF
--- a/plugin/cmake.vim
+++ b/plugin/cmake.vim
@@ -26,7 +26,7 @@ command! -nargs=? CMake call s:cmake(<f-args>)
 function! s:cmake(...)
 
   let s:build_dir = finddir('build', '.;')
-  let &makeprg='make --directory=' . s:build_dir
+  let &makeprg='cmake --build ' . s:build_dir
 
   exec 'cd' s:fnameescape(s:build_dir)
   


### PR DESCRIPTION
Here small fix to use cmake as make command from Vim.
Should be more cross-platform.
