### PR TITLE
Path escaping

### DIFF
--- a/plugin/cmake.vim
+++ b/plugin/cmake.vim
@@ -26,7 +26,7 @@ command! CMakeClean call s:cmakeclean()
 function! s:cmake(...)
 
   let s:build_dir = finddir('build', '.;')
-  let &makeprg='cmake --build ' . s:build_dir
+  let &makeprg='cmake --build ' . shellescape(s:build_dir)
 
   exec 'cd' s:fnameescape(s:build_dir)
 


### PR DESCRIPTION
If the build path contains spaces, the make command fails. Escaping s:build_dir solves the problem.
