### PR TITLE
Added support for custom target

### DIFF
--- a/plugin/cmake.vim
+++ b/plugin/cmake.vim
@@ -26,7 +26,7 @@ command! CMakeClean call s:cmakeclean()
 function! s:cmake(...)
 
   let s:build_dir = finddir('build', '.;')
-  let &makeprg='cmake --build ' . shellescape(s:build_dir)
+  let &makeprg='cmake --build ' . shellescape(s:build_dir) . ' --target '
 
   exec 'cd' s:fnameescape(s:build_dir)
 


### PR DESCRIPTION
By using the `--target` option it's possible to specify a custom
make target, for example `:make test`.
