### PR TITLE
Allow user to define cmake project generator.

### DIFF
--- a/doc/cmake.txt
+++ b/doc/cmake.txt
@@ -39,3 +39,5 @@ g:cmake_c_compiler               same as -DCMAKE_C_COMPILER, however, do note th
 g:cmake_build_shared_libs        same as -DBUILD_SHARED_LIBS
 
 g:cmake_build_dir                set the cmake 'build' directory, default: 'build'
+
+g:cmake_project_generator        set project generator

--- a/plugin/cmake.vim
+++ b/plugin/cmake.vim
@@ -36,6 +36,9 @@ function! s:cmake(...)
 
     let s:cleanbuild = 0
     let l:argument=[]
+    if exists("g:cmake_project_generator")
+      let l:argument+= [ "-G \"" . g:cmake_project_generator . "\"" ]
+    endif
     if exists("g:cmake_install_prefix")
       let l:argument+=  [ "-DCMAKE_INSTALL_PREFIX:FILEPATH="  . g:cmake_install_prefix ]
     endif


### PR DESCRIPTION
On Windows I'm using MinGW, but CMake by default uses installed Visual Studio.
I propose extra parameter set by user in vimrc to define generator he want to use. If he didn't - then default will be used.
