### PR TITLE
Handle spaces in directory name for cmake clean

### DIFF
--- a/plugin/cmake.vim
+++ b/plugin/cmake.vim
@@ -77,7 +77,7 @@ function! s:cmakeclean()
 
   let s:build_dir = finddir('build', '.;')
   if s:build_dir !=""
-    echo system("rm -r " . s:build_dir. "/*" )
+    echo system("rm -r '" . s:build_dir. "'/*" )
     echo "Build directory has been cleaned."
   else
     echo "Unable to find build directory."


### PR DESCRIPTION
I have a space in the path to my CMake build dir. Running cmakeclean would fail because of the system call missing quotes around the path. This fix adds single-quotes around the path to the build-dir.