### PR TITLE
Make working with cmake *alot* more convenient

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+test/test project/build/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,16 @@
+language: vim
+
+addons:
+  apt:
+    sources:
+    - ubuntu-toolchain-r-test
+    - kubuntu-backports
+    packages:
+    - g++-4.7
+    - cmake
+
+before_script: |
+  git clone https://github.com/junegunn/vader.vim.git
+
+script: |
+  vim -Nu 'test/.vimrc' -c 'Vader! test/cmake.vader'

--- a/README.md
+++ b/README.md
@@ -19,19 +19,27 @@ you can just use quickfix as with a normal Makefile project.
 
  * `:CMakeClean` deletes all files in the build directory. You can think of this as a CMake version of make clean.
 
+ * `:CMakeFindBuildDir` resets the build directory path set for the current buffer and then tries to find a new one. Useful if it previously found a wrong path to then reset it after a new build folder has been created for example.
+
 ### Variables
 
  * `g:cmake_install_prefix` same as `-DCMAKE_INSTALL_PREFIX`
 
  * `g:cmake_build_type` same as `-DCMAKE_BUILD_TYPE`
 
- * `g:cmake_cxx_compiler` same as `-DCMAKE_CXX_COMPILER`. The build directory will be cleared the next time you run :CMake.
+ * `g:cmake_cxx_compiler` same as `-DCMAKE_CXX_COMPILER`. Changes will have no effect until you run :CMakeClean and then :CMake.
 
- * `g:cmake_c_compiler` same as `-DCMAKE_C_COMPILER`. The build directory will be cleared the next time you run :CMake.
+ * `g:cmake_c_compiler` same as `-DCMAKE_C_COMPILER`. Changes will have no effect until you run :CMakeClean and then :CMake.
 
  * `g:cmake_build_shared_libs` same as `-DBUILD_SHARED_LIBS`
 
- * `g:cmake_project_generator` same as `-G`. The build directory will be cleared the next time you run :CMake.
+ * `g:cmake_project_generator` same as `-G`. Changes will have no effect until you run :CMakeClean and then :CMake.
+
+ * `g:cmake_export_compile_commands` same as `-DCMAKE_EXPORT_COMPILE_COMMANDS`.
+
+ * `g:cmake_ycm_symlinks` create symlinks to the generated compilation database for use with [YouCompleteMe](https://github.com/Valloric/YouCompleteMe/).
+
+ * `b:build_dir` is the path to the cmake build directory for the current buffer. This variable is set with the first :CMake or :CMakeFindBuildDir call. Once found, it will not be searched for again unless you call :CMakeFindBuildDir. If automatic finding is not sufficient you can set this variable manually to the build dir of your choice.
 
 
 ## Installation
@@ -56,6 +64,7 @@ With [Vundle.vim](https://github.com/VundleVim/Vundle.vim) simply add this repos
 ## Acknowledgements
 
  * Thanks to [Tim Pope](http://tpo.pe/), his plugins are really awesome.
+ * Thanks to [Junegunn Choi](https://junegunn.kr/), for [vader.vim](https://github.com/junegunn/vader.vim), which is the testing framework used for this plugin.
  * Also thanks to
     * @SteveDeFacto for extending this with more fine grained control.
     * @snikulov for enhancing makeprg.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 # vim-cmake
+[![Travis (Linux)](https://travis-ci.org/Squareys/vim-cmake.svg?branch=master)](https://travis-ci.org/Squareys/vim-cmake)
+[![AppVeyor (Windows)](https://ci.appveyor.com/api/projects/status/8x1tk0wbu4564m43?svg=true)](https://ci.appveyor.com/project/Squareys/vim-cmake)
 
 vim-cmake is a Vim plugin to make working with CMake a little nicer.
 

--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@
 
 vim-cmake is a Vim plugin to make working with CMake a little nicer.
 
-I got tired of navitating to the build directory each time, and I also 
-disliked setting makeprg manually each time. This plugin does just that. 
+I got tired of navigating to the build directory each time, and I also
+disliked setting makeprg manually each time. This plugin does just that.
 
 ## Usage
 
@@ -14,7 +14,7 @@ disliked setting makeprg manually each time. This plugin does just that.
  * `:CMake` searches for the closest directory named build in an upwards search,
 and whenever one is found, it runs the cmake command there, assuming the CMakeLists.txt
 file is just one directory above. Any arguments given to :CMake will be directly passed
-on to the cmake command. It also sets the working directory of the make command, so 
+on to the cmake command. It also sets the working directory of the make command, so
 you can just use quickfix as with a normal Makefile project.
 
  * `:CMakeClean` deletes all files in the build directory. You can think of this as a CMake version of make clean.
@@ -31,12 +31,15 @@ you can just use quickfix as with a normal Makefile project.
 
  * `g:cmake_build_shared_libs` same as `-DBUILD_SHARED_LIBS`
 
+ * `g:cmake_project_generator` same as `-G`. The build directory will be cleared the next time you run :CMake.
+
 
 ## Installation
 
-If you don't have a preferred installation method, I recommend
-installing [pathogen.vim](https://github.com/tpope/vim-pathogen), and
-then simply copy and paste:
+
+### Vim-pathogen
+
+With [pathogen.vim](https://github.com/tpope/vim-pathogen) simply copy and paste:
 
     cd ~/.vim/bundle
     git clone git://github.com/vhdirk/vim-cmake.git
@@ -44,13 +47,24 @@ then simply copy and paste:
 Once help tags have been generated, you can view the manual with
 `:help cmake`.
 
+### Vundle
 
+With [Vundle.vim](https://github.com/VundleVim/Vundle.vim) simply add this repository to your plugins list:
+
+    Plugin 'vhdirk/vim-cmake'
 
 ## Acknowledgements
 
  * Thanks to [Tim Pope](http://tpo.pe/), his plugins are really awesome.
- * Thanks to @SteveDeFacto for extending this with more fine grained control.
-
+ * Also thanks to
+    * @SteveDeFacto for extending this with more fine grained control.
+    * @snikulov for enhancing makeprg.
+    * @dapicester for allowing specifying targets.
+    * @thomasgubler for the build dir option.
+    * @antmd for fixing a bug with handing of spaces in directory names.
+    * @jmirabel for fixing concatenation of cmake arguments.
+    * @T4ng10r for the project generator option.
+    * @Squareys for a small overhaul of the project, the initial test and travis setup.
 
 ## License
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,10 @@
+os: Visual Studio 2015
+
+install:
+  - cinst vim
+  - cinst cmake
+  - set PATH=%PATH%;C:\Program Files\CMake\bin
+  - git clone https://github.com/junegunn/vader.vim
+
+build_script:
+  - vim -Nu test/.vimrc -c 'Vader! test/cmake.vader' --not-a-term

--- a/doc/cmake.txt
+++ b/doc/cmake.txt
@@ -47,3 +47,7 @@ OPTIONS                                        *cmake-options*
 g:cmake_export_compile_commands  same as -DCMAKE_EXPORT_COMPILE_COMMANDS=ON, useful for
                                  exporting a compilation database to be used with YCM
                                  (https://github.com/Valloric/YouCompleteMe#c-family-semantic-completion)
+                                 CMake only supports this flag with Ninja and Makefile generators.
+
+g:cmake_ycm_symlinks             create a symlink to the compile_commands.json file in the
+                                 root of the project (build/..) if the file is found.

--- a/doc/cmake.txt
+++ b/doc/cmake.txt
@@ -2,6 +2,7 @@
 
 Authors:  Dirk Van Haerenborgh <http://vhdirk.github.com/>
           Steven Batchelor <http://SteveDeFacto.github.com/>
+          Jonathan Hale <http://github.com/Squareys/>
 License: Same terms as Vim itself (see |license|)
 
 
@@ -19,8 +20,13 @@ COMMANDS                                        *cmake-commands*
                         Also modifies the :make command to build in
                         that directory.
 
-:CMakeClean                      deletes all files in the build directory. You can
-                                 think of this as a CMake version of make clean.
+:CMakeClean             deletes all files in the build directory. You can
+                        think of this as a CMake version of make clean.
+
+:CMakeFindBuildDir      resets the build directory path set for the current buffer
+                        and then tries to find a new one. Useful if it previously
+                        found a wrong path to then reset it after a new build folder
+                        has been created for example.
 
 VARIABLES                                        *cmake-variables*
 
@@ -41,6 +47,11 @@ g:cmake_build_dir                set the cmake 'build' directory, default: 'buil
 g:cmake_project_generator        set project generator, however, this will have
                                  no effect until you run :CMakeClean and :CMake.
 
+b:build_dir                      the path to the cmake build directory for the current buffer.
+                                 This variable is set with the first :CMake or :CMakeFindBuildDir call.
+                                 Once found, it will not be searched for again unless you call
+                                 :CMakeFindBuildDir. If automatic finding is not sufficient you can set
+                                 this variable manually to the build dir of your choice.
 
 OPTIONS                                        *cmake-options*
 

--- a/doc/cmake.txt
+++ b/doc/cmake.txt
@@ -28,16 +28,22 @@ g:cmake_install_prefix           same as -DCMAKE_INSTALL_PREFIX
 
 g:cmake_build_type               same as -DCMAKE_BUILD_TYPE
 
-g:cmake_cxx_compiler             same as -DCMAKE_CXX_COMPILER, however, do note that
-                                 the build directory will be cleared the next time you
-                                 run :CMake.
+g:cmake_cxx_compiler             same as -DCMAKE_CXX_COMPILER, however, this will have
+                                 no effect until you run :CMakeClean and :CMake.
 
-g:cmake_c_compiler               same as -DCMAKE_C_COMPILER, however, do note that the
-                                 build directory will be cleared the next time you
-                                 run :CMake.
+g:cmake_c_compiler               same as -DCMAKE_C_COMPILER, however, this will have
+                                 no effect until you run :CMakeClean and :CMake.
 
 g:cmake_build_shared_libs        same as -DBUILD_SHARED_LIBS
 
 g:cmake_build_dir                set the cmake 'build' directory, default: 'build'
 
-g:cmake_project_generator        set project generator
+g:cmake_project_generator        set project generator, however, this will have
+                                 no effect until you run :CMakeClean and :CMake.
+
+
+OPTIONS                                        *cmake-options*
+
+g:cmake_export_compile_commands  same as -DCMAKE_EXPORT_COMPILE_COMMANDS=ON, useful for
+                                 exporting a compilation database to be used with YCM
+                                 (https://github.com/Valloric/YouCompleteMe#c-family-semantic-completion)

--- a/plugin/cmake.vim
+++ b/plugin/cmake.vim
@@ -28,33 +28,32 @@ function! s:cmake(...)
   let g:cmake_build_dir = get(g:, 'cmake_build_dir', 'build')
   let s:build_dir = finddir(g:cmake_build_dir, '.;')
 
-  if s:build_dir !=""
-
-    let &makeprg='cmake --build ' . shellescape(s:build_dir) . ' --target '
+  if s:build_dir != ""
+    let &makeprg = 'cmake --build ' . shellescape(s:build_dir) . ' --target'
 
     exec 'cd' s:fnameescape(s:build_dir)
 
     let s:cleanbuild = 0
-    let l:argument=[]
+    let l:argument = []
     if exists("g:cmake_project_generator")
-      let l:argument+= [ "-G \"" . g:cmake_project_generator . "\"" ]
+      let l:argument += [ "-G \"" . g:cmake_project_generator . "\"" ]
     endif
     if exists("g:cmake_install_prefix")
-      let l:argument+=  [ "-DCMAKE_INSTALL_PREFIX:FILEPATH="  . g:cmake_install_prefix ]
+      let l:argument += [ "-DCMAKE_INSTALL_PREFIX:FILEPATH="  . g:cmake_install_prefix ]
     endif
     if exists("g:cmake_build_type" )
-      let l:argument+= [ "-DCMAKE_BUILD_TYPE:STRING="         . g:cmake_build_type ]
+      let l:argument += [ "-DCMAKE_BUILD_TYPE:STRING="         . g:cmake_build_type ]
     endif
     if exists("g:cmake_cxx_compiler")
-      let l:argument+= [ "-DCMAKE_CXX_COMPILER:FILEPATH="     . g:cmake_cxx_compiler ]
+      let l:argument += [ "-DCMAKE_CXX_COMPILER:FILEPATH="     . g:cmake_cxx_compiler ]
       let s:cleanbuild = 1
     endif
     if exists("g:cmake_c_compiler")
-      let l:argument+= [ "-DCMAKE_C_COMPILER:FILEPATH="       . g:cmake_c_compiler ]
+      let l:argument += [ "-DCMAKE_C_COMPILER:FILEPATH="       . g:cmake_c_compiler ]
       let s:cleanbuild = 1
     endif
     if exists("g:cmake_build_shared_libs")
-      let l:argument+= [ "-DBUILD_SHARED_LIBS:BOOL="          . g:cmake_build_shared_libs ]
+      let l:argument += [ "-DBUILD_SHARED_LIBS:BOOL="          . g:cmake_build_shared_libs ]
     endif
 
     let l:argumentstr = join(l:argument, " ")
@@ -68,7 +67,7 @@ function! s:cmake(...)
     let s:res = system(s:cmd)
     echo s:res
 
-    exec 'cd - '
+    exec 'cd -'
 
   else
     echo "Unable to find build directory."
@@ -79,8 +78,8 @@ endfunction
 function! s:cmakeclean()
 
   let s:build_dir = finddir('build', '.;')
-  if s:build_dir !=""
-    echo system("rm -r '" . s:build_dir. "'/*" )
+  if s:build_dir != ""
+    echo system("rm -r '" . s:build_dir. "'/*")
     echo "Build directory has been cleaned."
   else
     echo "Unable to find build directory."

--- a/plugin/cmake.vim
+++ b/plugin/cmake.vim
@@ -27,6 +27,7 @@ function! s:cmake_configure()
   let l:argument = []
   if exists("g:cmake_project_generator")
     let l:argument += [ "-G \"" . g:cmake_project_generator . "\"" ]
+    let s:cleanbuild = 1
   endif
   if exists("g:cmake_install_prefix")
     let l:argument += [ "-DCMAKE_INSTALL_PREFIX:FILEPATH="  . g:cmake_install_prefix ]

--- a/plugin/cmake.vim
+++ b/plugin/cmake.vim
@@ -26,6 +26,12 @@ function! s:find_build_dir()
     " Find build directory in path of current file
     let s:build_dir = finddir(g:cmake_build_dir, expand("%:p:h") . ';')
   endif
+
+  if s:build_dir != ""
+    " expand() would expand "" to working directory, but we need
+    " this as an indicator that build was not found
+    let s:build_dir = fnamemodify(s:build_dir, ':p')
+  endif
 endfunction
 
 " Configure the cmake project in the currently set build dir.

--- a/plugin/cmake.vim
+++ b/plugin/cmake.vim
@@ -12,6 +12,9 @@ endif
 " because the executable is not found. Otherwise the error message will be
 " displayed more than once.
 let loaded_cmake_plugin = 1
+if !exists("g:cmake_export_compile_commands")
+  let g:cmake_export_compile_commands = 0
+endif
 
 if !executable("cmake")
   echoerr "vim-cmake requires cmake executable. Please make sure it is installed and on PATH."
@@ -80,6 +83,9 @@ function! s:cmake_configure(force)
   endif
   if exists("g:cmake_build_shared_libs")
     let l:argument += [ "-DBUILD_SHARED_LIBS:BOOL="          . g:cmake_build_shared_libs ]
+  endif
+  if g:cmake_export_compile_commands
+    let l:argument += [ "-DCMAKE_EXPORT_COMPILE_COMMANDS=ON" ]
   endif
 
   let l:argumentstr = join(l:argument, " ")

--- a/plugin/cmake.vim
+++ b/plugin/cmake.vim
@@ -34,11 +34,11 @@ function! s:find_build_dir()
   endif
 
   let g:cmake_build_dir = get(g:, 'cmake_build_dir', 'build')
-  let b:build_dir = finddir(g:cmake_build_dir, expand(".") . ';')
+  let b:build_dir = finddir(g:cmake_build_dir, ';')
 
   if b:build_dir == ""
     " Find build directory in path of current file
-    let b:build_dir = finddir(g:cmake_build_dir, expand("%:p:h") . ';')
+    let b:build_dir = finddir(g:cmake_build_dir, s:fnameescape(expand("%:p:h")) . ';')
   endif
 
   if b:build_dir != ""

--- a/plugin/cmake.vim
+++ b/plugin/cmake.vim
@@ -81,7 +81,7 @@ function! s:cmake(...)
     let &makeprg = 'cmake --build ' . shellescape(s:build_dir) . ' --target'
     call s:cmake_configure()
   else
-    echo "Unable to find build directory."
+    echom "Unable to find build directory."
   endif
 
 endfunction
@@ -91,9 +91,9 @@ function! s:cmakeclean()
 
   if s:build_dir != ""
     echo system("rm -r '" . s:build_dir. "'/*")
-    echo "Build directory has been cleaned."
+    echom "Build directory has been cleaned."
   else
-    echo "Unable to find build directory."
+    echom "Unable to find build directory."
   endif
 
 endfunction

--- a/plugin/cmake.vim
+++ b/plugin/cmake.vim
@@ -15,6 +15,12 @@ function! s:find_build_dir()
 endfunction
 
 function! s:cmake_configure()
+  if filereadable(s:build_dir . "/CMakeCache.txt") && !s:cleanbuild
+    " Only change values of variables, if project is not configured
+    " already, otherwise we override existing configuration.
+    return
+  endif
+
   exec 'cd' s:fnameescape(s:build_dir)
 
   let s:cleanbuild = 0

--- a/plugin/cmake.vim
+++ b/plugin/cmake.vim
@@ -11,7 +11,7 @@ let loaded_cmake_plugin = 1
 
 function! s:find_build_dir()
   let g:cmake_build_dir = get(g:, 'cmake_build_dir', 'build')
-  let s:build_dir = finddir(g:cmake_build_dir, '.;')
+  let s:build_dir = expand(finddir(g:cmake_build_dir, '.;'))
 endfunction
 
 function! s:cmake_configure()

--- a/plugin/cmake.vim
+++ b/plugin/cmake.vim
@@ -20,7 +20,12 @@ endif
 
 function! s:find_build_dir()
   let g:cmake_build_dir = get(g:, 'cmake_build_dir', 'build')
-  let s:build_dir = expand(finddir(g:cmake_build_dir, '.;'))
+  let s:build_dir = finddir(g:cmake_build_dir, '.;')
+
+  if s:build_dir == ""
+    " Find build directory in path of current file
+    let s:build_dir = finddir(g:cmake_build_dir, expand("%:p:h") . ';')
+  endif
 endfunction
 
 " Configure the cmake project in the currently set build dir.

--- a/plugin/cmake.vim
+++ b/plugin/cmake.vim
@@ -88,7 +88,7 @@ function! s:cmake_configure(force)
     silent echo system("rm -r *" )
   endif
 
-  let s:cmd = 'cmake '. l:argumentstr . " " . join(a:000) .' .. '
+  let s:cmd = 'cmake .. '. l:argumentstr . " " . join(a:000)
   echo s:cmd
   silent let s:res = system(s:cmd)
   echo s:res

--- a/plugin/cmake.vim
+++ b/plugin/cmake.vim
@@ -9,6 +9,10 @@ if exists("loaded_cmake_plugin")
 endif
 let loaded_cmake_plugin = 1
 
+function! s:find_build_dir()
+  let g:cmake_build_dir = get(g:, 'cmake_build_dir', 'build')
+  let s:build_dir = finddir(g:cmake_build_dir, '.;')
+endfunction
 
 function! s:cmake_configure()
   exec 'cd' s:fnameescape(s:build_dir)
@@ -65,9 +69,7 @@ command! -nargs=? CMake call s:cmake(<f-args>)
 command! CMakeClean call s:cmakeclean()
 
 function! s:cmake(...)
-
-  let g:cmake_build_dir = get(g:, 'cmake_build_dir', 'build')
-  let s:build_dir = finddir(g:cmake_build_dir, '.;')
+  call s:find_build_dir()
 
   if s:build_dir != ""
     let &makeprg = 'cmake --build ' . shellescape(s:build_dir) . ' --target'
@@ -79,8 +81,8 @@ function! s:cmake(...)
 endfunction
 
 function! s:cmakeclean()
+  call s:find_build_dir()
 
-  let s:build_dir = finddir('build', '.;')
   if s:build_dir != ""
     echo system("rm -r '" . s:build_dir. "'/*")
     echo "Build directory has been cleaned."

--- a/plugin/cmake.vim
+++ b/plugin/cmake.vim
@@ -7,7 +7,16 @@ let s:cmake_plugin_version = '0.2'
 if exists("loaded_cmake_plugin")
   finish
 endif
+
+" We set this variable here even though the plugin may not actually be loaded
+" because the executable is not found. Otherwise the error message will be
+" displayed more than once.
 let loaded_cmake_plugin = 1
+
+if !executable("cmake")
+  echoerr "vim-cmake requires cmake executable. Please make sure it is installed and on PATH."
+  finish
+endif
 
 function! s:find_build_dir()
   let g:cmake_build_dir = get(g:, 'cmake_build_dir', 'build')

--- a/plugin/cmake.vim
+++ b/plugin/cmake.vim
@@ -85,12 +85,12 @@ function! s:cmake_configure(force)
   let l:argumentstr = join(l:argument, " ")
 
   if s:cleanbuild > 0
-    echo system("rm -r *" )
+    silent echo system("rm -r *" )
   endif
 
   let s:cmd = 'cmake '. l:argumentstr . " " . join(a:000) .' .. '
   echo s:cmd
-  let s:res = system(s:cmd)
+  silent let s:res = system(s:cmd)
   echo s:res
 
   exec 'cd -'
@@ -126,7 +126,7 @@ function! s:cmakeclean()
   call s:find_build_dir()
 
   if s:build_dir != ""
-    echo system("rm -r '" . s:build_dir. "'/*")
+    silent echo system("rm -r '" . s:build_dir. "'/*")
     echom "Build directory has been cleaned."
   else
     echom "Unable to find build directory."

--- a/plugin/cmake.vim
+++ b/plugin/cmake.vim
@@ -28,7 +28,7 @@ endif
 
 function! s:find_build_dir()
   let g:cmake_build_dir = get(g:, 'cmake_build_dir', 'build')
-  let s:build_dir = finddir(g:cmake_build_dir, '.;')
+  let s:build_dir = finddir(g:cmake_build_dir, expand(".") . ';')
 
   if s:build_dir == ""
     " Find build directory in path of current file

--- a/plugin/cmake.vim
+++ b/plugin/cmake.vim
@@ -93,7 +93,7 @@ function! s:cmake_configure()
   let s:cmd = 'cmake .. '. l:argumentstr . " " . join(a:000)
   echo s:cmd
   silent let s:res = system(s:cmd)
-  echo s:res
+  silent echo s:res
 
   " Create symbolic link to compilation database for use with YouCompleteMe
   if g:cmake_ycm_symlinks && filereadable("compile_commands.json")

--- a/plugin/cmake.vim
+++ b/plugin/cmake.vim
@@ -14,8 +14,23 @@ function! s:find_build_dir()
   let s:build_dir = expand(finddir(g:cmake_build_dir, '.;'))
 endfunction
 
-function! s:cmake_configure()
-  if filereadable(s:build_dir . "/CMakeCache.txt") && !s:cleanbuild
+" Configure the cmake project in the currently set build dir.
+"
+" :param force: Force configuration even if CMakeCache.txt already exists in
+" build dir. This will override any of the following variables if the
+" corresponding vim variable is set:
+"   * CMAKE_INSTALL_PREFIX
+"   * CMAKE_BUILD_TYPE
+"   * CMAKE_BUILD_SHARED_LIBS
+" In addition, previous configuration files will be deleted if the
+" corresponding vim variables for the following are set:
+"   * CMAKE_CXX_COMPILER
+"   * CMAKE_C_COMPILER
+"   * The generator
+"
+" Will do nothing if the project is already configured and force is disabled.
+function! s:cmake_configure(force)
+  if filereadable(s:build_dir . "/CMakeCache.txt") && !a:force
     " Only change values of variables, if project is not configured
     " already, otherwise we override existing configuration.
     return
@@ -80,7 +95,7 @@ function! s:cmake(...)
 
   if s:build_dir != ""
     let &makeprg = 'cmake --build ' . shellescape(s:build_dir) . ' --target'
-    call s:cmake_configure()
+    call s:cmake_configure(0)
   else
     echom "Unable to find build directory."
   endif

--- a/test/.vimrc
+++ b/test/.vimrc
@@ -1,0 +1,7 @@
+filetype off
+
+set rtp+=vader.vim
+set rtp+=.
+filetype plugin indent on
+syntax enable
+

--- a/test/cmake.vader
+++ b/test/cmake.vader
@@ -8,26 +8,31 @@ Before:
     let test_dir = fnamemodify(getcwd(), ':p')
   endif
 
-  Assert !isdirectory("test project/build"), "TEST ERROR: build directory was not properly deleted"
-  echo system("mkdir 'test project/build'")
-  Assert isdirectory("test project/build"), "TEST ERROR: build directory was not created"
+  Assert !isdirectory("test project/tmp-build"), "TEST ERROR: build directory was not properly deleted"
+  echo system("mkdir 'test project/tmp-build'")
+  Assert isdirectory("test project/tmp-build"), "TEST ERROR: build directory was not created"
 
+  " Under travis CI the entire project is in a build/ directory
+  " which will make the search from cwd always return a result.
+  " To be able to test searching build dir from current file, the
+  " build dir needs to be named differently as a workaround.
+  let g:cmake_build_dir = "tmp-build"
 After:
   exec "cd" fnameescape(test_dir)
-  echo system("rm -rf 'test project/build'")
+  echo system("rm -rf 'test project/tmp-build'")
   echo system("rm -f 'test project/compile_commands.json'")
 
 Execute (Find build directory from working dir):
   cd test\ project
   CMake
 
-  Assert filereadable("build/CMakeCache.txt"), "CMakeCache.txt should be generated"
-  Assert !filereadable("build/compile_commands.json"), "Compile commands should not be exported by default"
+  Assert filereadable("tmp-build/CMakeCache.txt"), "CMakeCache.txt should be generated"
+  Assert !filereadable("tmp-build/compile_commands.json"), "Compile commands should not be exported by default"
 
 Execute (Find build directory from currently open file):
   e test\ project/CMakeLists.txt
   CMake
-  Assert filereadable("test project/build/CMakeCache.txt"), "CMakeCache.txt should be generated"
+  Assert filereadable("test project/tmp-build/CMakeCache.txt"), "CMakeCache.txt should be generated"
 
 Execute (Create symlink to compilation database):
   let g:cmake_export_compile_commands = 1
@@ -37,12 +42,12 @@ Execute (Create symlink to compilation database):
 
   " Exporting compile commands does not work with Visual Studio generator
   if !has("win32") && !has("win32unix")
-    Assert filereadable("build/compile_commands.json"), "Compile commands should be exported"
+    Assert filereadable("tmp-build/compile_commands.json"), "Compile commands should be exported"
     Assert filereadable(resolve("compile_commands.json")), "A symlink should be generated"
   endif
 
 Execute (Open already configured cmake project):
-  cd test\ project/build
+  cd test\ project/tmp-build
   silent !cmake .. -DWITH_BYE=ON
   e ../CMakeLists.txt
   CMake

--- a/test/cmake.vader
+++ b/test/cmake.vader
@@ -8,10 +8,8 @@ Before:
     let test_dir = fnamemodify(getcwd(), ':p')
   endif
 
-  if !isdirectory("test project/build")
-    echo system("mkdir 'test project/build'")
-  endif
-
+  Assert !isdirectory("test project/build"), "TEST ERROR: build directory was not properly deleted"
+  echo system("mkdir 'test project/build'")
   Assert isdirectory("test project/build"), "TEST ERROR: build directory was not created"
 
 After:

--- a/test/cmake.vader
+++ b/test/cmake.vader
@@ -1,0 +1,48 @@
+Before:
+  " Ensure we are in the test directory
+  if isdirectory("test")
+    cd test
+  endif
+
+  if !exists("test_dir")
+    let test_dir = fnamemodify(getcwd(), ':p')
+  endif
+
+  if !isdirectory("test project/build")
+    echo system("mkdir 'test project/build'")
+  endif
+
+  Assert isdirectory("test project/build"), "TEST ERROR: build directory was not created"
+
+After:
+  exec "cd" fnameescape(test_dir)
+  echo system("rm -rf 'test project/build'")
+
+Execute (Find build directory from working dir):
+  cd test\ project
+  CMake
+
+  Assert filereadable("build/CMakeCache.txt"), "CMakeCache.txt should be generated"
+
+Execute (Find build directory from currently open file):
+  e test\ project/CMakeLists.txt
+  CMake
+  Assert filereadable("test project/build/CMakeCache.txt"), "CMakeCache.txt should be generated"
+
+Execute (Open already configured cmake project):
+  cd test\ project/build
+  silent !cmake .. -DWITH_BYE=ON
+  e ../CMakeLists.txt
+  CMake
+  silent make
+
+  enew
+  if has("win32") || has("win32unix")
+    read !Debug/hello.exe
+  else
+    read !./hello
+  endif
+Expect:
+
+  Hello World
+  Bye World

--- a/test/cmake.vader
+++ b/test/cmake.vader
@@ -17,17 +17,31 @@ Before:
 After:
   exec "cd" fnameescape(test_dir)
   echo system("rm -rf 'test project/build'")
+  echo system("rm -f 'test project/compile_commands.json'")
 
 Execute (Find build directory from working dir):
   cd test\ project
   CMake
 
   Assert filereadable("build/CMakeCache.txt"), "CMakeCache.txt should be generated"
+  Assert !filereadable("build/compile_commands.json"), "Compile commands should not be exported by default"
 
 Execute (Find build directory from currently open file):
   e test\ project/CMakeLists.txt
   CMake
   Assert filereadable("test project/build/CMakeCache.txt"), "CMakeCache.txt should be generated"
+
+Execute (Create symlink to compilation database):
+  let g:cmake_export_compile_commands = 1
+  let g:cmake_ycm_symlinks = 1
+  cd test\ project
+  CMake
+
+  " Exporting compile commands does not work with Visual Studio generator
+  if !has("win32") && !has("win32unix")
+    Assert filereadable("build/compile_commands.json"), "Compile commands should be exported"
+    Assert filereadable(resolve("compile_commands.json")), "A symlink should be generated"
+  endif
 
 Execute (Open already configured cmake project):
   cd test\ project/build

--- a/test/test project/CMakeLists.txt
+++ b/test/test project/CMakeLists.txt
@@ -1,0 +1,9 @@
+cmake_minimum_required(VERSION 2.8.12)
+
+project(HelloWorld)
+
+option(WITH_BYE "Print bye world" OFF)
+
+configure_file(configure.h.cmake configure.h)
+add_executable(hello main.cpp)
+target_include_directories(hello PRIVATE ${CMAKE_BINARY_DIR})

--- a/test/test project/configure.h.cmake
+++ b/test/test project/configure.h.cmake
@@ -1,0 +1,1 @@
+#cmakedefine WITH_BYE

--- a/test/test project/main.cpp
+++ b/test/test project/main.cpp
@@ -1,0 +1,10 @@
+#include <iostream>
+#include "configure.h"
+
+int main() {
+    std::cout << "Hello World" << std::endl;
+#ifdef WITH_BYE
+    std::cout << "Bye World" << std::endl;
+#endif
+    return 0;
+}


### PR DESCRIPTION
Hi everybody!

First of all: Thank you for creating this plugin! It served me well the last half a year. During that time I noticed some things that would be nice to have, some bugs and some minor annoyances.
The last three days I finally got around working on this plugin a bit and as a result here are my changes. High-Level summary of what I did:
 * Add vader.vim tests
 * Add CI configurations for Travis CI (Linux) and AppVeyor (Windows)
 * Update README.md to reflect previous contributions
 * Make this plugin help with using [YouCompleteMe](https://github.com/Valloric/YouCompleteMe) in CMake projects
 * Allow finding build directories from directory of file in current buffer if searching from working directory fails
 * Prevent clearing existing configurations implicitly (Can be horrible when working on larger projects)
 * Have build_dir stored per buffer to allow working with multiple CMake projects in one vim instance

For further information please refer to the commit history and commit messages, everything necessary should be explained there in detail.

I realize this grew to more commits than the project had in total, so I can fully understand if you are not happy with merging this. It would be amazing, though, if you could at least add a reference to my fork in the readme, if you decide not to accept my changes!

Thank you very much, kind regards,
Squareys.

PS: This PR is not compatible with #13 