### PR TITLE
Added variable for user arguments: g:cmake_usr_args

### DIFF
--- a/doc/cmake.txt
+++ b/doc/cmake.txt
@@ -41,3 +41,5 @@ g:cmake_build_shared_libs        same as -DBUILD_SHARED_LIBS
 g:cmake_build_dir                set the cmake 'build' directory, default: 'build'
 
 g:cmake_project_generator        set project generator
+
+g:cmake_usr_args                 custom user arguments. Ex: 'let g:cmake_usr_args="-DDEBUG=YES"'

--- a/plugin/cmake.vim
+++ b/plugin/cmake.vim
@@ -56,6 +56,9 @@ function! s:cmake(...)
     if exists("g:cmake_build_shared_libs")
       let l:argument+= [ "-DBUILD_SHARED_LIBS:BOOL="          . g:cmake_build_shared_libs ]
     endif
+    if exists("g:cmake_usr_args")
+      let l:argument+= [ g:cmake_usr_args ]
+    endif
 
     let l:argumentstr = join(l:argument, " ")
 


### PR DESCRIPTION
Added a global variable to allow users to specify custom arguments/options: ```g:cmake_usr_args```

Example:
```vim
let g:cmake_usr_args="-DDEBUG=YES -DCROSS_COMPILE=YES"
```