### PR TITLE
don't throw error when build_dir didn't exist yet

### DIFF
--- a/plugin/cmake.vim
+++ b/plugin/cmake.vim
@@ -139,7 +139,7 @@ command! CMakeClean call s:cmakeclean()
 command! CMakeFindBuildDir call s:cmake_find_build_dir()
 
 function! s:cmake_find_build_dir()
-  unlet b:build_dir
+  unlet! b:build_dir
   call s:find_build_dir()
 endfunction
 


### PR DESCRIPTION
`CMakeFindBuildDir` currently shows an error when `b:build_dir` wasn't set before.