### PR TITLE
Add deleted "AsyncRun" detection feature

### DIFF
--- a/plugin/cmake.vim
+++ b/plugin/cmake.vim
@@ -107,8 +107,14 @@ function! s:cmake_configure()
 
   let s:cmd = 'cmake .. '. l:argumentstr . " " . join(a:000)
   echo s:cmd
-  silent let s:res = system(s:cmd)
-  silent echo s:res
+  if exists(":AsyncRun")
+    execute 'copen'
+    execute 'AsyncRun ' . s:cmd
+    execute 'wincmd p'
+  else
+    silent let s:res = system(s:cmd)
+    silent echo s:res
+  endif
 
   " Create symbolic link to compilation database for use with YouCompleteMe
   if g:cmake_ycm_symlinks && filereadable("compile_commands.json")


### PR DESCRIPTION
The feature of "AsyncRun" utilization has been deleted **accidentally** at the commit 3286418bdc13ab585a228d94c22f074a975cd283.

I re-added the code and confirmed the feature to run.