### PR TITLE
changed cmake command to explicitely point to home directory and build directory

### DIFF
--- a/plugin/cmake.vim
+++ b/plugin/cmake.vim
@@ -104,8 +104,10 @@ function! s:cmake_configure()
   endif
 
   let l:argumentstr = join(l:argument, " ")
+  let l:home_dir = "-H".b:build_dir."/.."
+  let l:build_dir_path = "-B".b:build_dir
+  let s:cmd = 'cmake '.l:home_dir.' '.l:build_dir_path.' '.l:argumentstr . " " . join(a:000)
 
-  let s:cmd = 'cmake .. '. l:argumentstr . " " . join(a:000)
   echo s:cmd
   if exists(":AsyncRun")
     execute 'copen'


### PR DESCRIPTION
I ran into exactly same [issue](https://github.com/vhdirk/vim-cmake/issues/15#issue-237633027), and what worked for me was being more explicit about the build directory and home directory in the cmake command.