### PR TITLE
add build_toolchain_file configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ result of the cmake command in the quickfix as well.
 
  * `g:cmake_build_shared_libs` same as `-DBUILD_SHARED_LIBS`
 
+ * `g:cmake_toolchain_file` same as `-DCMAKE_TOOLCHAIN_FILE`
+
  * `g:cmake_project_generator` same as `-G`. Changes will have no effect until you run :CMakeClean and then :CMake.
 
  * `g:cmake_export_compile_commands` same as `-DCMAKE_EXPORT_COMPILE_COMMANDS`.

--- a/doc/cmake.txt
+++ b/doc/cmake.txt
@@ -42,6 +42,8 @@ g:cmake_c_compiler               same as -DCMAKE_C_COMPILER, however, this will 
 
 g:cmake_build_shared_libs        same as -DBUILD_SHARED_LIBS
 
+g:cmake_toolchain_file           same as -DCMAKE_TOOLCHAIN_FILE
+
 g:cmake_build_dir                set the cmake 'build' directory, default: 'build'
 
 g:cmake_project_generator        set project generator, however, this will have

--- a/plugin/cmake.vim
+++ b/plugin/cmake.vim
@@ -99,6 +99,9 @@ function! s:cmake_configure()
   if exists("g:cmake_build_shared_libs")
     let l:argument += [ "-DBUILD_SHARED_LIBS:BOOL="          . g:cmake_build_shared_libs ]
   endif
+  if exists("g:cmake_toolchain_file")
+    let l:argument += [ "-DCMAKE_TOOLCHAIN_FILE:FILEPATH="  . g:cmake_toolchain_file ]
+  endif
   if g:cmake_export_compile_commands
     let l:argument += [ "-DCMAKE_EXPORT_COMPILE_COMMANDS=ON" ]
   endif


### PR DESCRIPTION
The BUILD_TOOLCHAIN_FILE is an option that is helpful on windows when using vcpkg.  I am sure it is usful for other workflows as well. When commonly using the toolchain file for vcpkg, it will remain in my vimrc.

```
let g:cmake_toolchain_file = 'd:\dev\vcpkg\scripts\buildsystems\vcpkg.cmake'
```

Links of interest:
* [CMAKE_TOOLCHAIN_FILE](https://cmake.org/cmake/help/v3.18/variable/CMAKE_TOOLCHAIN_FILE.html)
* [vcpkg](https://github.com/microsoft/vcpkg)