### PR TITLE
Take into account the arguments passed to the vim command :CMake

### DIFF
--- a/plugin/cmake.vim
+++ b/plugin/cmake.vim
@@ -66,7 +66,7 @@ endfunction
 "   * CMAKE_CXX_COMPILER
 "   * CMAKE_C_COMPILER
 "   * The generator (-G)
-function! s:cmake_configure()
+function! s:cmake_configure(cmake_vim_command_args)
   exec 'cd' s:fnameescape(b:build_dir)
 
   let l:argument = []
@@ -107,7 +107,7 @@ function! s:cmake_configure()
   let l:escaped_build_dir=s:fnameescape(b:build_dir)
   let l:home_dir = "-H".l:escaped_build_dir."/.."
   let l:build_dir_path = "-B".l:escaped_build_dir
-  let s:cmd = 'cmake '.l:home_dir.' '.l:build_dir_path.' '.l:argumentstr . " " . join(a:000)
+  let s:cmd = 'cmake '.l:home_dir.' '.l:build_dir_path.' '.l:argumentstr . " " . join(a:cmake_vim_command_args)
 
   echo s:cmd
   if exists(":AsyncRun")
@@ -158,7 +158,7 @@ function! s:cmake(...)
   endif
 
   let &makeprg = 'cmake --build ' . shellescape(b:build_dir) . ' --target'
-  call s:cmake_configure()
+  call s:cmake_configure(a:000)
 endfunction
 
 function! s:cmakeclean()


### PR DESCRIPTION
When you enter the command :CMake, even if you add come parameters to the commands they are not actually added to the final shell command. Still, the help says that you can : 

:CMake [args]           Runs the cmake command as 'cmake ..', starting in
                                 first directory called 'build', found in an upwards
                                 search. All arguments are directly passed on to CMake.
                                 Also modifies the :make command to build in
                                 that directory.

This edit makes sure to pass the arguments of the :CMake vim command to the cmake_configure function.
