### PR TITLE
Pass target names directly to make

### DIFF
--- a/plugin/cmake.vim
+++ b/plugin/cmake.vim
@@ -178,7 +178,7 @@ function! s:cmake(...)
     let l:smp = ''
   endif
 
-  let &makeprg = 'cmake --build ' . shellescape(b:build_dir) . l:smp . ' --target'
+  let &makeprg = 'cmake --build ' . shellescape(b:build_dir) . l:smp . ' --'
   call s:cmake_configure(a:000)
 endfunction
 


### PR DESCRIPTION
Since 3.20 CMake errors out on unknown command line arguments or missing values.
https://gitlab.kitware.com/cmake/cmake/-/commit/1b6c5333a0b4a56eaf8b010084e18a40e473c2e3.

Calling `:Make` no longer works when no targets are specified.
```
|| CMake Error: Invalid value used with --target
|| Usage: cmake --build [<dir> | --preset <preset>] [options] [-- [native-options]]
|| Options:
||   <dir>          = Project binary directory to be built.
||   --preset <preset>, --preset=<preset>
||                  = Specify a build preset.
||   --list-presets
||                  = List available build presets.
||   --parallel [<jobs>], -j [<jobs>]
||                  = Build in parallel using the given number of jobs. 
||                    If <jobs> is omitted the native build tool's 
||                    default number is used.
||                    The CMAKE_BUILD_PARALLEL_LEVEL environment variable
||                    specifies a default parallel level when this option
||                    is not given.
||   --target <tgt>..., -t <tgt>... 
||                  = Build <tgt> instead of default targets.
||   --config <cfg> = For multi-configuration tools, choose <cfg>.
||   --clean-first  = Build target 'clean' first, then build.
||                    (To clean only, use --target 'clean'.)
||   --verbose, -v  = Enable verbose output - if supported - including
||                    the build commands to be executed. 
||   --             = Pass remaining options to the native tool.

```